### PR TITLE
chore: update GitHub Pages artifact action

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -23,7 +23,7 @@ jobs:
           ruby-version: "3.1"
           bundler-cache: true
       - run: bundle exec jekyll build
-      - uses: actions/upload-pages-artifact@v2
+      - uses: actions/upload-pages-artifact@v3
         with:
           path: _site
   deploy:
@@ -34,4 +34,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- use `actions/upload-pages-artifact@v3` so the workflow no longer depends on deprecated `actions/upload-artifact@v3`
- bump `actions/deploy-pages` to `v4`

## Testing
- `bundle exec jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_68b47a66b9588328842d5f169fd52ef4