### PR TITLE
chore: use Ruby 3.3 in CI

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.1"
+          ruby-version: "3.3"
           bundler-cache: true
       - run: bundle exec jekyll build
       - uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
## Summary
- align GitHub Actions with bundler 2.7 by using Ruby 3.3

## Testing
- `bundle _2.7.1_ exec jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_68b47bb568cc832891e395af24542cf6