### PR TITLE
Fix internal links and navigation paths

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,7 +18,14 @@ minimal_mistakes_skin: "sunrise"                    # try: aqua, contrast, dark.
 
 # Navigation + UI
 permalink: /:categories/:year/:month/:day/:title/
-breadcrumbs: true
+breadcrumbs: false
+
+category_archive:
+  type: jekyll-archives
+  path: /
+tag_archive:
+  type: jekyll-archives
+  path: /tema/
 paginate: 10
 paginate_path: "/page:num/"
 
@@ -47,7 +54,7 @@ jekyll-archives:
     category: archive
     tag: archive
   permalinks:
-    category: /categoria/:name/
+    category: /:name/
     tag: /tema/:name/
 
 # Social / SEO

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -2,11 +2,11 @@ main:
   - title: "Inicio"
     url: /
   - title: "Ciencia"
-    url: /categoria/ciencia/
+    url: /ciencia/
   - title: "Salud"
-    url: /categoria/salud/
+    url: /salud/
   - title: "Tecnología"
-    url: /categoria/tecnologia/
+    url: /tecnologia/
   - title: "Buscar"
     url: /buscar/
   - title: "Acerca de"

--- a/tag-archive.md
+++ b/tag-archive.md
@@ -1,6 +1,6 @@
 ---
 layout: tags
 title: "Temas"
-permalink: /temas/
+permalink: /tema/
 ---
 


### PR DESCRIPTION
## Summary
- configure category and tag archives for correct URLs
- update navigation links to point to new archive paths
- disable breadcrumbs to avoid links to nonexistent directories

## Testing
- `bundle exec jekyll build`
- `bundle exec htmlproofer --disable-external ./_site` *(fails: internal image /assets/images/logo.png does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68b485e4af808328a2b1e90c5beaa0f3