### PR TITLE
Localize Spanish UI text and update post dates

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,6 +5,7 @@ baseurl: ""  # keep empty on apex domain
 timezone: America/Santiago
 locale: es-CL
 lang: es-CL
+date_format: "%-d de %B de %Y"
 exclude:
   - Gemfile
   - Gemfile.lock

--- a/_data/ui-text.yml
+++ b/_data/ui-text.yml
@@ -113,6 +113,8 @@ es-ES:
   <<: *DEFAULT_ES
 es-CO:
   <<: *DEFAULT_ES
+es-CL:
+  <<: *DEFAULT_ES
 
 # French
 # ------

--- a/_posts/2025-08-30-bienvenida.md
+++ b/_posts/2025-08-30-bienvenida.md
@@ -1,6 +1,6 @@
 ---
 title: "Bienvenida a Noticiencias"
-date: 2024-08-30 14:04:19 -0400
+date: 2025-08-30 14:04:19 -0400
 categories:
   - ciencia
 tags:

--- a/_posts/2025-08-31-salud-prueba.md
+++ b/_posts/2025-08-31-salud-prueba.md
@@ -1,6 +1,6 @@
 ---
 title: "Prueba de Salud"
-date: 2024-08-31 10:00:00 -0400
+date: 2025-08-31 10:00:00 -0400
 categories:
   - salud
 tags:

--- a/_posts/2025-08-31-tecnologia-prueba.md
+++ b/_posts/2025-08-31-tecnologia-prueba.md
@@ -1,6 +1,6 @@
 ---
 title: "Prueba de Tecnología"
-date: 2024-08-31 11:00:00 -0400
+date: 2025-08-31 11:00:00 -0400
 categories:
   - tecnologia
 tags:


### PR DESCRIPTION
## Summary
- support Chilean Spanish UI strings for reading time
- format dates in Spanish
- update example posts to 2025 dates

## Testing
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_68b48bb072c48328abcf8f0ba28b5ae9