### PR TITLE
Mejorar localización en fechas y tiempos de lectura

### DIFF
--- a/_data/ui-text.yml
+++ b/_data/ui-text.yml
@@ -76,7 +76,9 @@ es: &DEFAULT_ES
   toc_label                  : "En esta página"
   ext_link_label             : "Enlace directo"
   less_than                  : "menos de"
-  minute_read                : "minuto(s) de lectura"
+  minute_read:
+    one                      : "minuto de lectura"
+    other                    : "minutos de lectura"
   share_on_label             : "Compartir en"
   meta_label                 :
   tags_label                 : "Etiquetas:"

--- a/_includes/page__date.html
+++ b/_includes/page__date.html
@@ -1,6 +1,15 @@
 {% assign date_format = site.date_format | default: "%B %-d, %Y" %}
 {% if page.last_modified_at %}
-  <p class="page__date"><strong><i class="fas fa-fw fa-calendar-alt" aria-hidden="true"></i> {{ site.data.ui-text[site.locale].date_label | default: "Updated:" }}</strong> <time class="dt-published" datetime="{{ page.last_modified_at | date: "%Y-%m-%d" }}">{{ page.last_modified_at | date: date_format }}</time></p>
+  {% assign formatted_date = page.last_modified_at | date: date_format %}
+  {% if site.locale contains 'es' %}
+  {% assign formatted_date = formatted_date | replace: 'January', 'enero' | replace: 'February', 'febrero' | replace: 'March', 'marzo' | replace: 'April', 'abril' | replace: 'May', 'mayo' | replace: 'June', 'junio' | replace: 'July', 'julio' | replace: 'August', 'agosto' | replace: 'September', 'septiembre' | replace: 'October', 'octubre' | replace: 'November', 'noviembre' | replace: 'December', 'diciembre' %}
+  {% endif %}
+  <p class="page__date"><strong><i class="fas fa-fw fa-calendar-alt" aria-hidden="true"></i> {{ site.data.ui-text[site.locale].date_label | default: "Updated:" }}</strong> <time class="dt-published" datetime="{{ page.last_modified_at | date: "%Y-%m-%d" }}">{{ formatted_date }}</time></p>
 {% elsif page.date %}
-  <p class="page__date"><strong><i class="fas fa-fw fa-calendar-alt" aria-hidden="true"></i> {{ site.data.ui-text[site.locale].date_label | default: "Updated:" }}</strong> <time class="dt-published" datetime="{{ page.date | date_to_xmlschema }}">{{ page.date | date: date_format }}</time></p>
+  {% assign formatted_date = page.date | date: date_format %}
+  {% if site.locale contains 'es' %}
+  {% assign formatted_date = formatted_date | replace: 'January', 'enero' | replace: 'February', 'febrero' | replace: 'March', 'marzo' | replace: 'April', 'abril' | replace: 'May', 'mayo' | replace: 'June', 'junio' | replace: 'July', 'julio' | replace: 'August', 'agosto' | replace: 'September', 'septiembre' | replace: 'October', 'octubre' | replace: 'November', 'noviembre' | replace: 'December', 'diciembre' %}
+  {% endif %}
+  <p class="page__date"><strong><i class="fas fa-fw fa-calendar-alt" aria-hidden="true"></i> {{ site.data.ui-text[site.locale].date_label | default: "Updated:" }}</strong> <time class="dt-published" datetime="{{ page.date | date_to_xmlschema }}">{{ formatted_date }}</time></p>
 {% endif %}
+

--- a/_includes/page__meta.html
+++ b/_includes/page__meta.html
@@ -5,8 +5,12 @@
       {% assign date = document.date %}
       <span class="page__meta-date">
         <i class="far {% if include.type == 'grid' and document.read_time and document.show_date %}fa-fw {% endif %}fa-calendar-alt" aria-hidden="true"></i>
-        {% assign date_format = site.date_format | default: "%B %-d, %Y" %}
-        <time datetime="{{ date | date_to_xmlschema }}">{{ date | date: date_format }}</time>
+          {% assign date_format = site.date_format | default: "%B %-d, %Y" %}
+          {% assign formatted_date = date | date: date_format %}
+          {% if site.locale contains 'es' %}
+          {% assign formatted_date = formatted_date | replace: 'January', 'enero' | replace: 'February', 'febrero' | replace: 'March', 'marzo' | replace: 'April', 'abril' | replace: 'May', 'mayo' | replace: 'June', 'junio' | replace: 'July', 'julio' | replace: 'August', 'agosto' | replace: 'September', 'septiembre' | replace: 'October', 'octubre' | replace: 'November', 'noviembre' | replace: 'December', 'diciembre' %}
+          {% endif %}
+          <time datetime="{{ date | date_to_xmlschema }}">{{ formatted_date }}</time>
       </span>
     {% endif %}
 
@@ -18,12 +22,16 @@
 
       <span class="page__meta-readtime">
         <i class="far {% if include.type == 'grid' and document.read_time and document.show_date %}fa-fw {% endif %}fa-clock" aria-hidden="true"></i>
-        {% if words < words_per_minute %}
-          {{ site.data.ui-text[site.locale].less_than | default: "less than" }} 1 {{ site.data.ui-text[site.locale].minute_read | default: "minute read" }}
-        {% elsif words == words_per_minute %}
-          1 {{ site.data.ui-text[site.locale].minute_read | default: "minute read" }}
+        {% assign minutes = words | divided_by: words_per_minute %}
+        {% assign minute_read = site.data.ui-text[site.locale].minute_read | default: "minute read" %}
+        {% assign minute_read_one = minute_read.one | default: minute_read %}
+        {% assign minute_read_other = minute_read.other | default: minute_read_one %}
+        {% if minutes < 1 %}
+          {{ site.data.ui-text[site.locale].less_than | default: "less than" }} 1 {{ minute_read_one }}
+        {% elsif minutes == 1 %}
+          1 {{ minute_read_one }}
         {% else %}
-          {{ words | divided_by: words_per_minute }} {{ site.data.ui-text[site.locale].minute_read | default: "minute read" }}
+          {{ minutes }} {{ minute_read_other }}
         {% endif %}
       </span>
     {% endif %}


### PR DESCRIPTION
## Resumen
- Mostrar meses en español en los metadatos y fechas de las páginas
- Ajustar la redacción del tiempo de lectura con singular y plural

## Testing
- `bundle install`
- `bundle exec jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_68b48d59f67083288c1ecd901a28c52b