### PR TITLE
Fix zero-size header logo

### DIFF
--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -5,7 +5,7 @@
     <div class="masthead__menu">
       <nav id="site-nav" class="greedy-nav">
         {% unless logo_path == empty %}
-          <a class="site-logo" href="{{ '/' | relative_url }}"><img src="{{ logo_path | relative_url }}" alt="{{ site.masthead_title | default: site.title }}"></a>
+          <a class="site-logo" href="{{ '/' | relative_url }}"><img src="{{ logo_path | relative_url }}" alt="{{ site.masthead_title | default: site.title }}" width="300" height="75"></a>
         {% endunless %}
         <a class="site-title" href="{{ '/' | relative_url }}">
           {{ site.masthead_title | default: site.title | escape_once | strip }}

--- a/assets/images/logo-noticiencias-signal-burst-horizontal.svg
+++ b/assets/images/logo-noticiencias-signal-burst-horizontal.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg viewBox="0 0 400 100" xmlns="http://www.w3.org/2000/svg">
+<svg width="300" height="75" viewBox="0 0 400 100" xmlns="http://www.w3.org/2000/svg">
     <!-- Signal Burst Logo - Horizontal -->
     <g transform="translate(0,10)">
         <path d="M8 12 L8 68 L18 68 L18 35 L42 59 L52 59 L52 12 L42 12 L42 47 L18 23 L8 12 Z" fill="#0B1B2B"/>


### PR DESCRIPTION
## Summary
- ensure horizontal logo SVG declares its intrinsic width and height
- give masthead logo image explicit dimensions so navigation layout can size it correctly

## Testing
- `bundle exec jekyll build` *(fails: "bundler: command not found: jekyll")*

------
https://chatgpt.com/codex/tasks/task_e_68b4a5608da88328802898b1a471f18d