### PR TITLE
Simplify header home navigation

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,6 +1,4 @@
 main:
-  - title: "Inicio"
-    url: /
   - title: "Ciencia"
     url: /ciencia/
   - title: "Salud"

--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -7,10 +7,10 @@
         {% unless logo_path == empty %}
           <a class="site-logo" href="{{ '/' | relative_url }}"><img src="{{ logo_path | relative_url }}" alt="{{ site.masthead_title | default: site.title }}" width="300" height="75"></a>
         {% endunless %}
-        <a class="site-title" href="{{ '/' | relative_url }}">
+        <span class="site-title">
           {{ site.masthead_title | default: site.title | escape_once | strip }}
           {% if site.subtitle %}<span class="site-subtitle">{{ site.subtitle | escape_once | strip }}</span>{% endif %}
-        </a>
+        </span>
         <ul class="visible-links">
           {%- for link in site.data.navigation.main -%}
             <li class="masthead__menu-item">


### PR DESCRIPTION
## Summary
- remove redundant `Inicio` link from main navigation
- display site title as plain text instead of a second home link

## Testing
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_68b4b9dc31c48328ad87afa120231f95