### PR TITLE
Fix highlight tag parsing in CHANGELOG and JS comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1258,18 +1258,18 @@
 
 ### Enhancements
 
-- Improve line numbered code block styling when using `{% highlight linenos %}` tag. [#513](https://github.com/mmistakes/minimal-mistakes/issues/513)
+- Improve line numbered code block styling when using `&#123;% highlight linenos %&#125;` tag. [#513](https://github.com/mmistakes/minimal-mistakes/issues/513)
 - Add English fallback to "Follow" button label. [#496](https://github.com/mmistakes/minimal-mistakes/pull/496)
 
 ### Bug Fixes
 
-- Fix Firefox alignment issues with code blocks generated with the `{% highlight %}` tag. [#512](https://github.com/mmistakes/minimal-mistakes/issues/512)
+- Fix Firefox alignment issues with code blocks generated with the `&#123;% highlight %&#125;` tag. [#512](https://github.com/mmistakes/minimal-mistakes/issues/512)
 
 ### Maintenance
 
 - Clarified comment for `author.stackoverflow` value used in author sidebar links. [#487](https://github.com/mmistakes/minimal-mistakes/pull/487)
 - Add list of localized text strings. [#488](https://github.com/mmistakes/minimal-mistakes/pull/488)
-- Add `{% highlight %}` code block examples to demo site.
+- Add `&#123;% highlight %&#125;` code block examples to demo site.
 - Add documentation for using custom sidebar navigation menus. [#476](https://github.com/mmistakes/minimal-mistakes/issues/476)
 
 ## [3.4.4](https://github.com/mmistakes/minimal-mistakes/releases/tag/3.4.4)

--- a/assets/js/_main.js
+++ b/assets/js/_main.js
@@ -191,7 +191,7 @@ $(document).ready(function () {
       throw new Error("No code block found for this button.");
     }
 
-    // Skip line numbers if present (i.e. {% highlight lineno %})
+    // Skip line numbers if present (i.e. &#123;% highlight lineno %&#125;)
     var realCodeBlock = codeBlock.querySelector("td.code, td.rouge-code");
     if (realCodeBlock) {
       codeBlock = realCodeBlock;


### PR DESCRIPTION
## Summary
- escape Liquid highlight tags in CHANGELOG to prevent Jekyll from parsing them
- escape highlight tag example in main JS comment

## Testing
- `bundle exec jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_68ba02f48e588328ad7c4c45300c560f