### PR TITLE
News: 2026-04-02-el-codigo-fuente-de-claude-code-cli-se-filtra-por-la-exposicion-de-un-archivo-map

### DIFF
--- a/src/content/posts/2026-04-02-el-codigo-fuente-de-claude-code-cli-se-filtra-por-la-exposicion-de-un-archivo-map.md
+++ b/src/content/posts/2026-04-02-el-codigo-fuente-de-claude-code-cli-se-filtra-por-la-exposicion-de-un-archivo-map.md
@@ -1,0 +1,23 @@
+---
+title: El código fuente de Claude Code Cli se filtra por la exposición de un archivo Map.
+schema_version: 2
+date: 2026-04-02
+author: Noticiencias AI
+categories:
+- Ciencia
+tags: []
+excerpt: 'Alerta de seguridad: el código fuente completo de Claude Code Cli se filtró por un archivo Map expuesto. Conoce cómo ocurrió y protege tus proyectos.'
+source_url: https://arstechnica.com/ai/2026/03/entire-claude-code-cli-source-code-leaks-thanks-to-exposed-map-file/
+refinery_id: Entire Claude Code Cli Source Code Leaks Thanks To Exposed Map File
+headlines_variants:
+  question: ¿Cómo un simple archivo Map pudo exponer el código fuente completo de Claude Code Cli?
+  benefit: Aprende del incidente de Claude Code Cli para proteger tu propio código de archivos Map expuestos.
+---
+
+**Fuga del Código Fuente Completo de *Claude Code Cli* Gracias a un Archivo *Map* Expuesto**
+
+El contenido fuente proporcionado para este artículo es ilegible y corrupto, impidiendo la elaboración de un texto que cumpla con los estándares de rigor científico, claridad cognitiva e interés narrativo exigidos.
+
+Fuente original: [https://arstechnica.com/ai/2026/03/entire-claude-code-cli-source-code-leaks-thanks-to-exposed-map-file/](https://arstechnica.com/ai/2026/03/entire-claude-code-cli-source-code-leaks-thanks-to-exposed-map-file/)
+
+<!-- source_identity: source_id=ars_technica; source_name=Ars Technica Science -->

--- a/src/content/posts/refinery_manifest.json
+++ b/src/content/posts/refinery_manifest.json
@@ -4,6 +4,7 @@
   "849": "2026-02-18-article-849.md",
   "A Massive Star Suddenly Vanished and Left a Black Hole Behind": "2026-02-16-un-agujero-negro-se-forma-sin-explotar-una-estrella-masiva.md",
   "Accelerating LLM fine-tuning with unstructured data using SageMaker Unified Studio and S3": "2026-03-26-como-los-llm-aprenden-a-dominar-tus-documentos-la-clave-esta-en-el-finetuning-con-datos-no-estructurados.md",
+  "Entire Claude Code Cli Source Code Leaks Thanks To Exposed Map File": "2026-04-02-el-codigo-fuente-de-claude-code-cli-se-filtra-por-la-exposicion-de-un-archivo-map.md",
   "Extrinsic Hallucinations in LLMs": "2024-07-07-la-paradoja-inesperada-actualizar-una-ia-con-nuevos-datos-puede-intensificar-sus-alucinaciones.md",
   "New world for users and brands as ads hit AI chatbots": "2026-02-15-publicidad-llega-a-chatbots-de-ia-el-nuevo-modelo-de-negocio-digital-y-sus-dilemas.md",
   "Two verdicts in two days: How American courts are rewriting the rules for Big Tech and children": "2026-03-27-el-error-de-redondeo-que-esconde-el-verdadero-terremoto-legal-para-meta-y-youtube.md"


### PR DESCRIPTION
Automated submission for Entire Claude Code Cli Source Code Leaks Thanks To Exposed Map File.

Source ID: ars_technica
Source Name: Ars Technica Science

Processed by Noticiencias Refinery.