### PR TITLE
fix(ci): add concurrency group and timeouts to Content Guard

### DIFF
--- a/.github/workflows/content-guard.yml
+++ b/.github/workflows/content-guard.yml
@@ -9,6 +9,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: content-guard-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   BACKEND_CONTRACT_REPOSITORY: cortega26/noticiencias_news_collector
@@ -18,6 +22,7 @@ env:
 jobs:
   validate:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -77,6 +82,7 @@ jobs:
     if: github.event_name == 'pull_request'
     needs: validate
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 


### PR DESCRIPTION
## Summary

- Añade `concurrency: group: content-guard-${{ github.ref }}, cancel-in-progress: true` al workflow para que pushes rápidos a la misma rama cancelen la ejecución anterior en lugar de encolarla.
- Añade `timeout-minutes: 15` a los jobs `validate` y `build` como red de seguridad ante un link-checker o build de Astro colgado.

Complementa el fix de Dependabot mergeado en PR #109.

## Test plan

- [ ] Verificar que dos pushes rápidos al mismo PR cancelan el run anterior
- [ ] Confirmar que validate y build completan normalmente dentro de 15 min

🤖 Generated with [Claude Code](https://claude.com/claude-code)