### PR TITLE
[codex] remove obsolete Node 24 forcing flag

### DIFF
--- a/.github/workflows/content-guard.yml
+++ b/.github/workflows/content-guard.yml
@@ -14,7 +14,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   BACKEND_CONTRACT_REPOSITORY: cortega26/noticiencias_news_collector
   BACKEND_CONTRACT_REF: main
   BACKEND_CONTRACT_SCHEMA_PATH: news_collector/contracts/frontend_schema.py

--- a/.github/workflows/image-delivery-quota.yml
+++ b/.github/workflows/image-delivery-quota.yml
@@ -24,7 +24,6 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   AUTOMATION_BRANCH: automation/image-delivery-mode
   R2_BUCKET_NAME: ${{ secrets.CLOUDFLARE_R2_BUCKET_NAME }}
   CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
## What changed

- Removed the obsolete `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` workflow environment setting.
- Kept the repository's intentional project/runtime Node version configuration unchanged.

## Why

GitHub-hosted Actions runners now use Node 24 by default. The pre-migration forcing flag is redundant and can cause workflow failures after the migration.

## Impact

JavaScript actions use the runner's default Node 24 runtime without an obsolete override. Application runtime behavior is unchanged.

## Validation

- Workflow YAML parsed successfully.
- `git diff --check` passed.
- Confirmed the forcing flag no longer appears in `.github/`.

## Rollback

Revert this commit.
