### PR TITLE
fix(ci): bot sync PRs fail their own lint gate on unformatted snapshot

### DIFF
--- a/.contract-snapshots/frontend_schema.snapshot.json
+++ b/.contract-snapshots/frontend_schema.snapshot.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedAt": "2026-06-24T18:02:55.740Z",
+  "generatedAt": "2026-08-04T15:50:07.799Z",
   "backendRef": "main",
   "pythonIR": {
     "version": 1,

--- a/.github/workflows/generate-metrics.yml
+++ b/.github/workflows/generate-metrics.yml
@@ -13,7 +13,10 @@ permissions:
 jobs:
   generate:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # 25 min: checkout + npm ci (~2-3 min) plus the 15-min PR-check poll loop
+    # in scripts/ci-land-bot-pr.sh (runner queue delays can push Content Guard
+    # far past the PR creation time).
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 

--- a/.github/workflows/sync-contract-snapshot.yml
+++ b/.github/workflows/sync-contract-snapshot.yml
@@ -13,7 +13,10 @@ permissions:
 jobs:
   sync-snapshot:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # 25 min: checkout + npm ci (~2-3 min) plus the 15-min PR-check poll loop
+    # in scripts/ci-land-bot-pr.sh (runner queue delays can push Content Guard
+    # far past the PR creation time).
+    timeout-minutes: 25
     steps:
       - name: Checkout frontend repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/scripts/check-contract-sync.js
+++ b/scripts/check-contract-sync.js
@@ -20,6 +20,7 @@
 
 import { readFileSync, writeFileSync, statSync } from 'fs';
 import { resolve, dirname } from 'path';
+import { format } from 'prettier';
 
 // ---------------------------------------------------------------------------
 // CLI argument parsing
@@ -1314,7 +1315,7 @@ function printReport(diffs, strictMode = false) {
 // Main
 // ---------------------------------------------------------------------------
 
-function main() {
+async function main() {
   let pyIr, tsIr;
 
   if (mode === 'generate-snapshot') {
@@ -1364,7 +1365,11 @@ function main() {
 
     const outPath = resolve(generatePath);
     try {
-      writeFileSync(outPath, JSON.stringify(snapshot, null, 2));
+      // Format through Prettier (parser json) so the committed snapshot always
+      // passes `npm run format:check` in the Content Guard lint step — the bot
+      // workflow and local `sync:contract-snapshot` runs both commit this file.
+      const formatted = await format(JSON.stringify(snapshot, null, 2), { parser: 'json' });
+      writeFileSync(outPath, formatted);
       console.log(`[contract-sync] Snapshot written to ${outPath}`);
       console.log(
         `[contract-sync] Python fields: ${pyIr.models['AstroPost'].fields.length} top-level, ${Object.keys(pyIr.models).length - 1} nested models`
@@ -1467,4 +1472,4 @@ function main() {
   process.exit(exitCode);
 }
 
-main();
+await main();

--- a/scripts/ci-land-bot-pr.sh
+++ b/scripts/ci-land-bot-pr.sh
@@ -20,13 +20,17 @@ TITLE="$2"
 gh pr create --base main --head "$BRANCH" --title "$TITLE" \
   --body "Automated change committed by a scheduled workflow; merged automatically once required checks pass."
 
-for i in $(seq 1 60); do
+# 90 polls x 10s = 15 min. Longer than a plain 10-min window so runner queue
+# delays (Content Guard can sit queued for tens of minutes) don't mask a
+# later check failure as a timeout.
+for i in $(seq 1 90); do
   CHECKS=$(gh pr checks "$BRANCH" --required 2>/dev/null || true)
   if [ -n "$CHECKS" ]; then
     FAILED=$(printf '%s\n' "$CHECKS" | grep -c $'\tfail' || true)
     PENDING=$(printf '%s\n' "$CHECKS" | grep -c $'\tpending' || true)
     if [ "$FAILED" -gt 0 ]; then
       echo "::error::PR checks failed for ${BRANCH}."
+      printf '%s\n' "$CHECKS"
       exit 1
     fi
     if [ "$PENDING" -eq 0 ]; then
@@ -39,4 +43,6 @@ for i in $(seq 1 60); do
 done
 
 echo "::error::Timed out waiting for required checks on ${BRANCH} — PR left open for manual merge."
+echo "Last known check state:"
+gh pr checks "$BRANCH" --required 2>/dev/null || echo "(no required checks reported yet)"
 exit 1


### PR DESCRIPTION
Fixes the Sync Contract Snapshot / Generate Content Metrics bot pipeline failing its own Content Guard lint gate.

**Root cause:** `scripts/check-contract-sync.js` wrote the snapshot with `JSON.stringify(snapshot, null, 2)` — nested `unionTypes` arrays come out multi-line with no trailing newline, so the file fails `npm run format:check`. Every bot-generated snapshot PR was blocked by its own validate job.

**Changes:**
- `check-contract-sync.js` — format snapshot through Prettier (`parser: json`) before writing, so bot and local `sync:contract-snapshot` runs emit lint-clean output
- `ci-land-bot-pr.sh` — poll window 10 min → 15 min to ride out runner queue delays; on timeout, print last known required-check state so failures are visible
- `sync-contract-snapshot.yml`, `generate-metrics.yml` — job timeout 15 → 25 min to fit the longer poll loop

The regenerated snapshot now differs from main only by `generatedAt` (verified locally). Closes the loop on PR #116, which was left open blocked by this defect.