### PR TITLE
fix(ci): credit bot pushes and PRs to a PAT so checks run ungated

### DIFF
--- a/.github/workflows/generate-metrics.yml
+++ b/.github/workflows/generate-metrics.yml
@@ -40,8 +40,17 @@ jobs:
       - name: Commit and land metrics
         # Direct pushes to main are rejected by branch protection; land via PR
         # (scripts/ci-land-bot-pr.sh merges once Content Guard passes).
+        #
+        # GH_TOKEN uses NOTICIENCIAS_BOT_TOKEN (fine-grained PAT with
+        # contents: write + pull-requests: write on this repo) when set:
+        # events triggered by the plain GITHUB_TOKEN are gated by GitHub's
+        # bot-approval mechanism — pull_request workflows on bot-created PRs
+        # conclude `action_required` with zero jobs and never run, so bot PRs
+        # could never validate or merge. A PAT-credited push/PR is attributed
+        # to a human and runs ungated. Falls back to GITHUB_TOKEN when the
+        # secret is not configured.
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.NOTICIENCIAS_BOT_TOKEN || github.token }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -52,5 +61,9 @@ jobs:
           fi
           git commit -m "chore: update pipeline metrics"
           BRANCH="ci/metrics-$(date -u +%Y%m%dT%H%M%SZ)"
-          git push -u origin "HEAD:$BRANCH"
+          if [ -n "$GH_TOKEN" ]; then
+            git push -u "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:$BRANCH"
+          else
+            git push -u origin "HEAD:$BRANCH"
+          fi
           bash scripts/ci-land-bot-pr.sh "$BRANCH" "chore: update pipeline metrics"

--- a/.github/workflows/image-delivery-quota.yml
+++ b/.github/workflows/image-delivery-quota.yml
@@ -86,6 +86,11 @@ jobs:
         if: steps.evaluate.outcome == 'success' && steps.quota_summary.outputs.mode_changed == 'true'
         env:
           BASE_BRANCH: ${{ github.event.repository.default_branch }}
+          # Fine-grained PAT (contents: write + pull-requests: write) when set:
+          # events triggered by the plain GITHUB_TOKEN are gated by GitHub's
+          # bot-approval mechanism, so bot-created PRs never validate or merge.
+          # Falls back to GITHUB_TOKEN when the secret is not configured.
+          GH_TOKEN: ${{ secrets.NOTICIENCIAS_BOT_TOKEN || github.token }}
         run: |
           git checkout -B "$AUTOMATION_BRANCH" "origin/$BASE_BRANCH"
           git config user.name "github-actions[bot]"
@@ -96,13 +101,22 @@ jobs:
             exit 0
           fi
           git commit -m "chore: switch image delivery mode to ${{ steps.quota_summary.outputs.target_mode }}"
-          git push --force-with-lease origin "HEAD:$AUTOMATION_BRANCH"
+          if [ -n "$GH_TOKEN" ]; then
+            git push --force-with-lease "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:$AUTOMATION_BRANCH"
+          else
+            git push --force-with-lease origin "HEAD:$AUTOMATION_BRANCH"
+          fi
 
       - name: Create or update pull request
         id: create_pr
         if: steps.evaluate.outcome == 'success' && steps.quota_summary.outputs.mode_changed == 'true'
         env:
-          GH_TOKEN: ${{ github.token }}
+          # Fine-grained PAT (contents: write + pull-requests: write) when set:
+          # pull_request workflows on bot-created PRs conclude `action_required`
+          # with zero jobs when the PR was opened with the plain GITHUB_TOKEN,
+          # so they never validate or merge. A PAT-created PR is attributed to
+          # a human and runs ungated. Falls back to GITHUB_TOKEN.
+          GH_TOKEN: ${{ secrets.NOTICIENCIAS_BOT_TOKEN || github.token }}
           BASE_BRANCH: ${{ github.event.repository.default_branch }}
           REQUESTED_MODE: ${{ github.event.inputs.mode || 'auto' }}
         run: |

--- a/.github/workflows/sync-contract-snapshot.yml
+++ b/.github/workflows/sync-contract-snapshot.yml
@@ -48,12 +48,22 @@ jobs:
 
       - name: Commit and land snapshot update if changed
         # Direct pushes to main are rejected by branch protection (required
-        # checks), so land the snapshot through a PR (scripts/ci-land-bot-pr.sh
-        # merges it once Content Guard passes). Hooks are bypassed: the husky
-        # pre-push hook runs the full validate:content chain (incl. the flaky
-        # link check) on the runner and would abort the bot push.
+        # checks validate + build), so land the snapshot through a PR
+        # (scripts/ci-land-bot-pr.sh merges it once Content Guard passes).
+        # Hooks are bypassed: the husky pre-push hook runs the full
+        # validate:content chain (incl. the flaky link check) on the runner
+        # and would abort the bot push.
+        #
+        # GH_TOKEN uses NOTICIENCIAS_BOT_TOKEN (fine-grained PAT with
+        # contents: write + pull-requests: write on this repo) when set:
+        # events triggered by the plain GITHUB_TOKEN are gated by GitHub's
+        # bot-approval mechanism — pull_request workflows on bot-created PRs
+        # conclude `action_required` with zero jobs and never run, so bot PRs
+        # could never validate or merge. A PAT-credited push/PR is attributed
+        # to a human and runs ungated. Falls back to GITHUB_TOKEN when the
+        # secret is not configured.
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.NOTICIENCIAS_BOT_TOKEN || github.token }}
         run: |
           git config core.hooksPath /dev/null
           git config user.name "github-actions[bot]"
@@ -65,5 +75,13 @@ jobs:
           fi
           git commit -m "chore: sync contract schema snapshot"
           BRANCH="sync/contract-snapshot-$(date -u +%Y%m%dT%H%M%SZ)"
-          git push -u origin "HEAD:$BRANCH"
+          # Push with the configured token (PAT when set) so the head commit
+          # is credited to a human, not github-actions[bot]. Without this the
+          # branch protection can treat the bot push as a workflow-triggering
+          # action and gate the checks.
+          if [ -n "$GH_TOKEN" ]; then
+            git push -u "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:$BRANCH"
+          else
+            git push -u origin "HEAD:$BRANCH"
+          fi
           bash scripts/ci-land-bot-pr.sh "$BRANCH" "chore: sync contract schema snapshot"


### PR DESCRIPTION
GitHub gates events triggered by the plain `GITHUB_TOKEN`: `pull_request` workflows on bot-created PRs conclude `action_required` with **zero jobs** and never run — confirmed live on today's `sync-contract-snapshot` PRs (Content Guard gated, validate never executed, bot poll timed out, PR left blocked).

**Change:** all three PR-creating bot workflows now use a fine-grained PAT (`NOTICIENCIAS_BOT_TOKEN`: contents: write + pull-requests: write on this repo) for the branch push **and** the PR create, falling back to `GITHUB_TOKEN` when the secret is absent:
- `sync-contract-snapshot.yml`
- `generate-metrics.yml`
- `image-delivery-quota.yml`

A PAT-credited push/PR is attributed to a human, so `pull_request` workflows run ungated.

**Action required:** create the `NOTICIENCIAS_BOT_TOKEN` repo secret (Settings → Secrets and variables → Actions → New repository secret). Until then the workflows behave exactly as before.