### PR TITLE
fix(dashboard): slug category links through cleanSlug to strip accents

### DIFF
--- a/src/pages/admin/dashboard.astro
+++ b/src/pages/admin/dashboard.astro
@@ -6,6 +6,7 @@ import DashboardHealthList from '~/components/ds/organisms/DashboardHealthList.a
 
 import { readFileSync, existsSync } from 'node:fs';
 import { resolve } from 'node:path';
+import { cleanSlug } from '~/utils/permalinks';
 
 const metricsPath = resolve('data/metrics/pipeline-metrics.json');
 let metrics: Record<string, any> | null = null;
@@ -167,7 +168,7 @@ const metadata = {
               {topCategories.map((cat) => (
                 <li class="px-5 py-3 flex items-center justify-between">
                   <a
-                    href={`/categorias/${cat.name.toLowerCase().replace(/\s+/g, '-')}`}
+                    href={`/categorias/${cleanSlug(cat.name)}`}
                     class="text-sm font-medium text-primary hover:underline"
                   >
                     {cat.name}


### PR DESCRIPTION
The admin dashboard hand-rolled category slugs with `name.toLowerCase().replace(/\s+/g, '-')`, which kept accented characters (`Tecnología` → `/categorias/tecnología`) while the real taxonomy routes use `cleanSlug`/limax (accent-stripped: `/categorias/tecnologia`). The generated links 404'd — caught by the site-integrity audit in the Content Guard build job.

This only surfaced once the metrics bot landed `data/metrics/pipeline-metrics.json` and the dashboard began rendering real categories. Fix: route the links through the canonical `cleanSlug` helper (URL contract in AGENTS.md: no hand-rolled route strings).