### PR TITLE
fix(bot): prevent no-op churn PRs, self-clean stale bot PRs, warn on missing PAT

### DIFF
--- a/.github/workflows/generate-metrics.yml
+++ b/.github/workflows/generate-metrics.yml
@@ -37,6 +37,10 @@ jobs:
         # must not run lint-staged or the full validation chain on the runner.
         run: git config core.hooksPath /dev/null
 
+      - name: Warn when bot PAT is not configured
+        if: ${{ secrets.NOTICIENCIAS_BOT_TOKEN == '' }}
+        run: echo "::warning::NOTICIENCIAS_BOT_TOKEN secret is not configured — bot PRs fall back to GITHUB_TOKEN and are gated by GitHub bot-approval (checks conclude action_required and never run), so the bot cannot land PRs. Configure the fine-grained PAT to enable self-serve landing."
+
       - name: Commit and land metrics
         # Direct pushes to main are rejected by branch protection; land via PR
         # (scripts/ci-land-bot-pr.sh merges once Content Guard passes).
@@ -54,6 +58,14 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # Self-cleanup: the bot exits 1 when checks fail or the merge times
+          # out and leaves the PR open; close any stale bot PRs from previous
+          # failed runs and delete their branches so debris cannot accumulate.
+          while IFS=$'\t' read -r pr_number branch_name; do
+            gh pr close "$pr_number" --comment "Superseded by a newer metrics run." || true
+            gh api "repos/${GITHUB_REPOSITORY}/git/refs/heads/${branch_name}" -X DELETE --silent || true
+          done < <(gh pr list --base main --state open --json number,headRefName \
+            --jq '.[] | select(.headRefName | startswith("ci/metrics-")) | [.number, .headRefName] | @tsv' 2>/dev/null || true)
           git add data/metrics/pipeline-metrics.json
           if git diff --cached --quiet; then
             echo "Metrics already up to date."

--- a/.github/workflows/image-delivery-quota.yml
+++ b/.github/workflows/image-delivery-quota.yml
@@ -82,6 +82,10 @@ jobs:
           fs.appendFileSync(process.env.GITHUB_OUTPUT, `target_mode=${summary.targetMode}\n`, 'utf8');
           EOF
 
+      - name: Warn when bot PAT is not configured
+        if: ${{ secrets.NOTICIENCIAS_BOT_TOKEN == '' }}
+        run: echo "::warning::NOTICIENCIAS_BOT_TOKEN secret is not configured — bot PRs fall back to GITHUB_TOKEN and are gated by GitHub bot-approval (checks conclude action_required and never run). Configure the fine-grained PAT to enable self-serve landing."
+
       - name: Commit mode update to automation branch
         if: steps.evaluate.outcome == 'success' && steps.quota_summary.outputs.mode_changed == 'true'
         env:

--- a/.github/workflows/sync-contract-snapshot.yml
+++ b/.github/workflows/sync-contract-snapshot.yml
@@ -46,6 +46,10 @@ jobs:
           BACKEND_SCHEMA_PATH="_backend_sparse/news_collector/contracts/frontend_schema.py" \
             npm run sync:contract-snapshot
 
+      - name: Warn when bot PAT is not configured
+        if: ${{ secrets.NOTICIENCIAS_BOT_TOKEN == '' }}
+        run: echo "::warning::NOTICIENCIAS_BOT_TOKEN secret is not configured — bot PRs fall back to GITHUB_TOKEN and are gated by GitHub bot-approval (checks conclude action_required and never run), so the bot cannot land PRs. Configure the fine-grained PAT to enable self-serve landing."
+
       - name: Commit and land snapshot update if changed
         # Direct pushes to main are rejected by branch protection (required
         # checks validate + build), so land the snapshot through a PR
@@ -68,6 +72,14 @@ jobs:
           git config core.hooksPath /dev/null
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # Self-cleanup: the bot exits 1 when checks fail or the merge times
+          # out and leaves the PR open; close any stale bot PRs from previous
+          # failed runs and delete their branches so debris cannot accumulate.
+          while IFS=$'\t' read -r pr_number branch_name; do
+            gh pr close "$pr_number" --comment "Superseded by a newer sync run." || true
+            gh api "repos/${GITHUB_REPOSITORY}/git/refs/heads/${branch_name}" -X DELETE --silent || true
+          done < <(gh pr list --base main --state open --json number,headRefName \
+            --jq '.[] | select(.headRefName | startswith("sync/contract-snapshot-")) | [.number, .headRefName] | @tsv' 2>/dev/null || true)
           git add .contract-snapshots/frontend_schema.snapshot.json
           if git diff --cached --quiet; then
             echo "Contract snapshot already up to date."

--- a/scripts/check-contract-sync.js
+++ b/scripts/check-contract-sync.js
@@ -1364,6 +1364,19 @@ async function main() {
     };
 
     const outPath = resolve(generatePath);
+    // Preserve the existing generatedAt when the extracted IR is unchanged so
+    // no-op regenerations (weekly bot runs with no backend drift) produce an
+    // empty diff and the workflow's `git diff --cached --quiet` guard skips
+    // the commit/PR — otherwise every run opens a timestamp-only PR.
+    try {
+      const existing = JSON.parse(readFileSync(outPath, 'utf-8'));
+      if (existing && JSON.stringify(existing.pythonIR) === JSON.stringify(snapshot.pythonIR)) {
+        snapshot.generatedAt = existing.generatedAt;
+      }
+    } catch {
+      // No existing snapshot; keep the fresh timestamp.
+    }
+
     try {
       // Format through Prettier (parser json) so the committed snapshot always
       // passes `npm run format:check` in the Content Guard lint step — the bot

--- a/scripts/generate-metrics.js
+++ b/scripts/generate-metrics.js
@@ -15,7 +15,11 @@ import { fileURLToPath } from 'node:url';
 import matter from 'gray-matter';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const REPO_ROOT = resolve(__dirname, '..');
+// METRICS_ROOT override is used by the test suite to run against a temp
+// fixture tree instead of the repository itself.
+const REPO_ROOT = process.env.METRICS_ROOT
+  ? resolve(process.env.METRICS_ROOT)
+  : resolve(__dirname, '..');
 const POSTS_DIR = resolve(REPO_ROOT, 'src', 'content', 'posts');
 const METRICS_DIR = resolve(REPO_ROOT, 'data', 'metrics');
 const METRICS_FILE = resolve(METRICS_DIR, 'pipeline-metrics.json');
@@ -189,6 +193,34 @@ function collectImageMetrics() {
 // Main
 // ---------------------------------------------------------------------------
 
+/**
+ * Preserve the existing timestamps when the meaningful metrics are unchanged.
+ *
+ * The scheduled bot workflow skips the commit/PR via `git diff --cached
+ * --quiet`; without this guard every daily run would rewrite generated_at and
+ * open + auto-merge a "chore: update pipeline metrics" PR that only bumps the
+ * timestamp. The output must be byte-identical to the committed file for the
+ * diff to stay empty.
+ */
+function preserveTimestampsWhenUnchanged(report) {
+  let existing;
+  try {
+    existing = JSON.parse(readFileSync(METRICS_FILE, 'utf-8'));
+  } catch {
+    return;
+  }
+
+  const stripTimestamps = (r) =>
+    JSON.parse(JSON.stringify(r, (key, value) => (key === 'generated_at' ? undefined : value)));
+
+  if (JSON.stringify(stripTimestamps(existing)) !== JSON.stringify(stripTimestamps(report))) {
+    return;
+  }
+
+  report.generated_at = existing.generated_at || report.generated_at;
+  report.pipeline.generated_at = existing.pipeline?.generated_at || report.pipeline.generated_at;
+}
+
 function main() {
   const content = collectContentMetrics();
   const pipeline = collectPipelineMetrics();
@@ -200,6 +232,8 @@ function main() {
     pipeline,
     images,
   };
+
+  preserveTimestampsWhenUnchanged(report);
 
   // Write metrics file
   mkdirSync(METRICS_DIR, { recursive: true });

--- a/tests/contract-sync.test.ts
+++ b/tests/contract-sync.test.ts
@@ -6,8 +6,10 @@
  */
 
 import { execSync } from 'child_process';
-import { readFileSync, unlinkSync, existsSync } from 'fs';
-import { resolve } from 'path';
+import { readFileSync, writeFileSync, mkdtempSync, rmSync, unlinkSync, existsSync } from 'fs';
+import { join, resolve } from 'path';
+import { tmpdir } from 'os';
+import { format } from 'prettier';
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 
 const SCRIPT = resolve('scripts/check-contract-sync.js');
@@ -128,6 +130,57 @@ describe('check-contract-sync', () => {
     it('exits 2 when Python file does not exist and no snapshot fallback', () => {
       const result = runSync('/nonexistent/py.py /nonexistent/ts.ts');
       expect(result.exitCode).toBe(2);
+    });
+  });
+
+  // ── generatedAt no-churn contract ──────────────────────────────
+  // The scheduled Sync Contract Snapshot bot skips the commit/PR via
+  // `git diff --cached --quiet`; if regeneration always bumped generatedAt
+  // the diff would never be empty and every weekly run would open and merge
+  // a timestamp-only PR. The generator must preserve generatedAt when the
+  // extracted Python IR is unchanged and bump it only on real drift.
+  describe('generatedAt no-churn contract', () => {
+    const TMP = mkdtempSync(join(tmpdir(), 'contract-sync-gen-'));
+    const SNAPSHOT_PATH = join(TMP, 'snapshot.json');
+    const PY_PATH = resolve('tests/fixtures/contract-sync/simple_py.py');
+    const TS_PATH = resolve('tests/fixtures/contract-sync/simple_ts.ts');
+    const CHANGED_PY_PATH = join(TMP, 'changed_py.py');
+
+    afterAll(() => {
+      rmSync(TMP, { recursive: true, force: true });
+    });
+
+    it('preserves generatedAt when the Python IR is unchanged', () => {
+      runSync(`--generate-snapshot ${SNAPSHOT_PATH} ${PY_PATH} ${TS_PATH}`);
+      const first = JSON.parse(readFileSync(SNAPSHOT_PATH, 'utf-8'));
+
+      runSync(`--generate-snapshot ${SNAPSHOT_PATH} ${PY_PATH} ${TS_PATH}`);
+      const second = JSON.parse(readFileSync(SNAPSHOT_PATH, 'utf-8'));
+
+      expect(second.generatedAt).toBe(first.generatedAt);
+      expect(second.pythonIR).toEqual(first.pythonIR);
+    });
+
+    it('bumps generatedAt when the Python IR changes', () => {
+      runSync(`--generate-snapshot ${SNAPSHOT_PATH} ${PY_PATH} ${TS_PATH}`);
+      const first = JSON.parse(readFileSync(SNAPSHOT_PATH, 'utf-8'));
+
+      writeFileSync(
+        CHANGED_PY_PATH,
+        `${readFileSync(PY_PATH, 'utf-8')}\nclass ExtraModel(BaseModel):\n    extra_field: str\n`,
+        'utf-8'
+      );
+      runSync(`--generate-snapshot ${SNAPSHOT_PATH} ${CHANGED_PY_PATH} ${TS_PATH}`);
+
+      const second = JSON.parse(readFileSync(SNAPSHOT_PATH, 'utf-8'));
+      expect(second.generatedAt).not.toBe(first.generatedAt);
+      expect(second.pythonIR.models.ExtraModel).toBeDefined();
+    });
+
+    it('writes a Prettier-formatted snapshot that passes format:check', async () => {
+      const raw = readFileSync(SNAPSHOT_PATH, 'utf-8');
+      const normalized = await format(JSON.stringify(JSON.parse(raw), null, 2), { parser: 'json' });
+      expect(raw).toBe(normalized);
     });
   });
 });

--- a/tests/dashboard-category-links.test.ts
+++ b/tests/dashboard-category-links.test.ts
@@ -1,0 +1,86 @@
+/**
+ * dashboard-category-links.test.ts
+ *
+ * Regression guard for the admin dashboard category link bug: the dashboard
+ * once hand-rolled slugs with `name.toLowerCase().replace(/\s+/g, '-')`,
+ * which kept accented characters (Tecnología -> /categorias/tecnología) while
+ * the real taxonomy routes use cleanSlug (limax). The generated links 404'd
+ * and only the dist audit in CI caught it. These tests pin the shared slug
+ * rule used by both the routes and the dashboard, and verify that every
+ * category label in the committed metrics file slugifies to a safe path
+ * segment.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { readFileSync, existsSync } from 'fs';
+import { resolve } from 'path';
+
+vi.mock('astrowind:config', () => ({
+  SITE: { base: '/', trailingSlash: false, site: 'https://example.com' },
+  APP_BLOG: {
+    isEnabled: true,
+    isRelatedPostsEnabled: true,
+    postsPerPage: 10,
+    list: { isEnabled: true, robots: {}, pathname: 'blog' },
+    post: { isEnabled: true, robots: {}, permalink: '%category%/%slug%' },
+    category: { isEnabled: true, robots: {}, pathname: 'categorias' },
+    tag: { isEnabled: true, robots: {}, pathname: 'temas' },
+  },
+}));
+
+vi.mock('~/utils/utils', () => ({
+  trim: (value: string, delimiter = '') => {
+    if (!delimiter) {
+      return value.trim();
+    }
+
+    const escapedDelimiter = delimiter.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const edgePattern = new RegExp(`^${escapedDelimiter}+|${escapedDelimiter}+$`, 'g');
+    return value.replace(edgePattern, '');
+  },
+}));
+
+const ASCII_SLUG = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+
+describe('dashboard category links', () => {
+  it('cleanSlug strips accents the same way the taxonomy routes do', async () => {
+    const { cleanSlug } = await import('../src/utils/permalinks');
+
+    const cases: Array<[string, string]> = [
+      ['Tecnología', 'tecnologia'],
+      ['Astronomía', 'astronomia'],
+      ['Arqueología', 'arqueologia'],
+      ['Física', 'fisica'],
+      ['Química', 'quimica'],
+      ['Salud Pública', 'salud-publica'],
+    ];
+
+    for (const [name, expected] of cases) {
+      expect(cleanSlug(name), `slug for "${name}"`).toBe(expected);
+    }
+  });
+
+  it('documents why the old hand-rolled slug rule produced broken links', async () => {
+    const { cleanSlug } = await import('../src/utils/permalinks');
+
+    // Pre-fix the dashboard built hrefs with name.toLowerCase().replace(/\s+/g, '-')
+    // which kept accented characters — the exact bug the dist audit caught.
+    const handRolled = 'Tecnología'.toLowerCase().replace(/\s+/g, '-');
+    expect(handRolled).not.toMatch(ASCII_SLUG);
+    expect(cleanSlug('Tecnología')).toMatch(ASCII_SLUG);
+  });
+
+  it('every category in the committed metrics file slugifies to a safe path segment', async () => {
+    const METRICS = resolve('data/metrics/pipeline-metrics.json');
+    expect(existsSync(METRICS), `missing ${METRICS}`).toBe(true);
+
+    const report = JSON.parse(readFileSync(METRICS, 'utf-8'));
+    const names: string[] = report.content.categories.map((c: { name: string }) => c.name);
+    expect(names.length).toBeGreaterThan(0);
+
+    const { cleanSlug } = await import('../src/utils/permalinks');
+    for (const name of names) {
+      expect(cleanSlug(name), `slug for metrics category "${name}"`).toMatch(ASCII_SLUG);
+    }
+  });
+});

--- a/tests/generate-metrics.test.ts
+++ b/tests/generate-metrics.test.ts
@@ -1,0 +1,120 @@
+/**
+ * generate-metrics.test.ts
+ *
+ * Regression tests for scripts/generate-metrics.js, focused on the no-churn
+ * contract with the scheduled bot workflow: the output file must be
+ * byte-identical on no-op re-runs (otherwise `git diff --cached --quiet` in
+ * the workflow never triggers and the bot opens an auto-merging PR every day
+ * that only bumps generated_at).
+ *
+ * Runs the script against a temp fixture tree via the METRICS_ROOT override.
+ */
+
+import { execFileSync } from 'child_process';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync, existsSync } from 'fs';
+import { tmpdir } from 'os';
+import { join, resolve } from 'path';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+const SCRIPT = resolve('scripts/generate-metrics.js');
+
+function runGenerator(root: string): string {
+  return execFileSync(process.execPath, [SCRIPT], {
+    env: { ...process.env, METRICS_ROOT: root },
+    encoding: 'utf-8',
+    timeout: 30_000,
+  });
+}
+
+function metricsPath(root: string): string {
+  return join(root, 'data', 'metrics', 'pipeline-metrics.json');
+}
+
+function writePost(root: string, name: string, overrides: Record<string, unknown> = {}) {
+  const base = [
+    '---',
+    'title: Test post',
+    'date: 2026-01-01',
+    'categories: [Ciencia]',
+    'tags: [fisica]',
+    'schema_version: 2',
+    'summary_points: [one]',
+    'glossary: [{ term: a, definition: b }]',
+    'fact_check: [{ claim: c, status: verified }]',
+    'why_it_matters: reason',
+    'confidence: 0.9',
+    'sources: [{ title: s, url: https://example.com }]',
+    '---',
+    '',
+    'Body text for the post.',
+  ];
+  for (const [key, value] of Object.entries(overrides)) {
+    const idx = base.findIndex((l) => l.startsWith(`${key}:`));
+    if (idx >= 0) base[idx] = `${key}: ${value}`;
+    else base.splice(base.length - 2, 0, `${key}: ${value}`);
+  }
+  writeFileSync(join(root, 'src', 'content', 'posts', name), base.join('\n'), 'utf-8');
+}
+
+function readMetrics(root: string): Record<string, any> {
+  return JSON.parse(readFileSync(metricsPath(root), 'utf-8'));
+}
+
+describe('generate-metrics no-churn contract', () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'noticiencias-metrics-'));
+    mkdirSync(join(root, 'src', 'content', 'posts'), { recursive: true });
+    mkdirSync(join(root, 'data', 'metrics'), { recursive: true });
+    writePost(root, 'science-1.md');
+    writePost(root, 'tech-1.md', { title: 'Tech post', categories: '[Tecnología]' });
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('produces byte-identical output on consecutive no-op runs', () => {
+    runGenerator(root);
+    const first = readFileSync(metricsPath(root), 'utf-8');
+    runGenerator(root);
+    const second = readFileSync(metricsPath(root), 'utf-8');
+    expect(second).toBe(first);
+  });
+
+  it('preserves existing generated_at when the meaningful content is unchanged', () => {
+    runGenerator(root);
+    const metrics = readMetrics(root);
+    const sentinel = '2000-01-01T00:00:00.000Z';
+    metrics.generated_at = sentinel;
+    metrics.pipeline.generated_at = sentinel;
+    writeFileSync(metricsPath(root), JSON.stringify(metrics, null, 2), 'utf-8');
+
+    runGenerator(root);
+
+    const rerun = readMetrics(root);
+    expect(rerun.generated_at).toBe(sentinel);
+    expect(rerun.pipeline.generated_at).toBe(sentinel);
+  });
+
+  it('bumps generated_at when the content changes', () => {
+    runGenerator(root);
+    const first = readMetrics(root);
+
+    writePost(root, 'health-1.md', { title: 'Health post', categories: '[Salud]' });
+    runGenerator(root);
+    const second = readMetrics(root);
+
+    expect(second.content.total_articles).toBe(first.content.total_articles + 1);
+    expect(second.generated_at).not.toBe(first.generated_at);
+  });
+
+  it('writes the metrics file on first run even when the directory is empty', () => {
+    rmSync(join(root, 'src', 'content', 'posts', 'science-1.md'));
+    rmSync(join(root, 'src', 'content', 'posts', 'tech-1.md'));
+    runGenerator(root);
+    expect(existsSync(metricsPath(root))).toBe(true);
+    expect(readMetrics(root).content.total_articles).toBe(0);
+  });
+});


### PR DESCRIPTION
## Problem

The scheduled bot workflows could never take their empty-diff 'already up to date' path: both generators unconditionally rewrote their timestamp, so `git diff --cached --quiet` was never empty and every scheduled run opened + auto-merged a timestamp-only PR — **daily** for Generate Content Metrics, **weekly** for Sync Contract Snapshot.

Additionally, failed bot runs (check failure or poll timeout) left their PRs and branches open forever — three had to be closed manually in the last session — and a missing `NOTICIENCIAS_BOT_TOKEN` silently fell back to the bot-gated `GITHUB_TOKEN` path.

## Changes

- `scripts/generate-metrics.js`: preserve `generated_at` (top-level and pipeline) when the meaningful metrics are unchanged → byte-identical output → empty diff → bot skips. Added `METRICS_ROOT` env override for fixture-based tests.
- `scripts/check-contract-sync.js`: preserve `generatedAt` when the extracted Python IR is unchanged.
- `generate-metrics.yml` + `sync-contract-snapshot.yml`: each run closes stale bot PRs from previous failed runs (branch prefixes `ci/metrics-\*/`sync/contract-snapshot-\*`) and deletes their branches.
- All three bot workflows: explicit `::warning::` when `NOTICIENCIAS_BOT_TOKEN` is not configured.

## Tests (10 new)

- `tests/generate-metrics.test.ts`: byte-identical no-op re-run, timestamp preservation, timestamp bump on content change, empty-posts edge.
- `tests/contract-sync.test.ts`: generatedAt preserved when IR unchanged, bumped when changed, Prettier-stable output.
- `tests/dashboard-category-links.test.ts`: pins the cleanSlug accent-stripping contract (the bug the metrics PR exposed) and verifies every category in the committed metrics file slugifies to a safe path segment.

## Verification

- `npm run lint`, `npm run validate:content`, `npm run build`, `npm run test:dist`, `npm run test:audit` (262 passed), `npm run check:contract-sync` — all green.
- Real-repo regeneration of both artifacts produces **zero git diff** (churn fix proven locally).