### PR TITLE
fix(workflows): warn on missing PAT via env check, not secrets in if:

### DIFF
--- a/.github/workflows/generate-metrics.yml
+++ b/.github/workflows/generate-metrics.yml
@@ -38,9 +38,12 @@ jobs:
         run: git config core.hooksPath /dev/null
 
       - name: Warn when bot PAT is not configured
-        if: secrets.NOTICIENCIAS_BOT_TOKEN == ''
-        run: echo "::warning::NOTICIENCIAS_BOT_TOKEN secret is not configured — bot PRs fall back to GITHUB_TOKEN and are gated by GitHub bot-approval (checks conclude action_required and never run), so the bot cannot land PRs. Configure the fine-grained PAT to enable self-serve landing."
-
+        env:
+          GH_TOKEN: ${{ secrets.NOTICIENCIAS_BOT_TOKEN || '' }}
+        run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::warning::NOTICIENCIAS_BOT_TOKEN secret is not configured - bot PRs fall back to GITHUB_TOKEN and are gated by GitHub bot-approval (checks conclude action_required and never run). Configure the fine-grained PAT to enable self-serve landing."
+          fi
       - name: Commit and land metrics
         # Direct pushes to main are rejected by branch protection; land via PR
         # (scripts/ci-land-bot-pr.sh merges once Content Guard passes).

--- a/.github/workflows/generate-metrics.yml
+++ b/.github/workflows/generate-metrics.yml
@@ -38,7 +38,7 @@ jobs:
         run: git config core.hooksPath /dev/null
 
       - name: Warn when bot PAT is not configured
-        if: ${{ secrets.NOTICIENCIAS_BOT_TOKEN == '' }}
+        if: secrets.NOTICIENCIAS_BOT_TOKEN == ''
         run: echo "::warning::NOTICIENCIAS_BOT_TOKEN secret is not configured — bot PRs fall back to GITHUB_TOKEN and are gated by GitHub bot-approval (checks conclude action_required and never run), so the bot cannot land PRs. Configure the fine-grained PAT to enable self-serve landing."
 
       - name: Commit and land metrics

--- a/.github/workflows/image-delivery-quota.yml
+++ b/.github/workflows/image-delivery-quota.yml
@@ -83,9 +83,12 @@ jobs:
           EOF
 
       - name: Warn when bot PAT is not configured
-        if: secrets.NOTICIENCIAS_BOT_TOKEN == ''
-        run: echo "::warning::NOTICIENCIAS_BOT_TOKEN secret is not configured — bot PRs fall back to GITHUB_TOKEN and are gated by GitHub bot-approval (checks conclude action_required and never run). Configure the fine-grained PAT to enable self-serve landing."
-
+        env:
+          GH_TOKEN: ${{ secrets.NOTICIENCIAS_BOT_TOKEN || '' }}
+        run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::warning::NOTICIENCIAS_BOT_TOKEN secret is not configured - bot PRs fall back to GITHUB_TOKEN and are gated by GitHub bot-approval (checks conclude action_required and never run). Configure the fine-grained PAT to enable self-serve landing."
+          fi
       - name: Commit mode update to automation branch
         if: steps.evaluate.outcome == 'success' && steps.quota_summary.outputs.mode_changed == 'true'
         env:

--- a/.github/workflows/image-delivery-quota.yml
+++ b/.github/workflows/image-delivery-quota.yml
@@ -83,7 +83,7 @@ jobs:
           EOF
 
       - name: Warn when bot PAT is not configured
-        if: ${{ secrets.NOTICIENCIAS_BOT_TOKEN == '' }}
+        if: secrets.NOTICIENCIAS_BOT_TOKEN == ''
         run: echo "::warning::NOTICIENCIAS_BOT_TOKEN secret is not configured — bot PRs fall back to GITHUB_TOKEN and are gated by GitHub bot-approval (checks conclude action_required and never run). Configure the fine-grained PAT to enable self-serve landing."
 
       - name: Commit mode update to automation branch

--- a/.github/workflows/sync-contract-snapshot.yml
+++ b/.github/workflows/sync-contract-snapshot.yml
@@ -47,9 +47,12 @@ jobs:
             npm run sync:contract-snapshot
 
       - name: Warn when bot PAT is not configured
-        if: secrets.NOTICIENCIAS_BOT_TOKEN == ''
-        run: echo "::warning::NOTICIENCIAS_BOT_TOKEN secret is not configured — bot PRs fall back to GITHUB_TOKEN and are gated by GitHub bot-approval (checks conclude action_required and never run), so the bot cannot land PRs. Configure the fine-grained PAT to enable self-serve landing."
-
+        env:
+          GH_TOKEN: ${{ secrets.NOTICIENCIAS_BOT_TOKEN || '' }}
+        run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::warning::NOTICIENCIAS_BOT_TOKEN secret is not configured - bot PRs fall back to GITHUB_TOKEN and are gated by GitHub bot-approval (checks conclude action_required and never run). Configure the fine-grained PAT to enable self-serve landing."
+          fi
       - name: Commit and land snapshot update if changed
         # Direct pushes to main are rejected by branch protection (required
         # checks validate + build), so land the snapshot through a PR

--- a/.github/workflows/sync-contract-snapshot.yml
+++ b/.github/workflows/sync-contract-snapshot.yml
@@ -47,7 +47,7 @@ jobs:
             npm run sync:contract-snapshot
 
       - name: Warn when bot PAT is not configured
-        if: ${{ secrets.NOTICIENCIAS_BOT_TOKEN == '' }}
+        if: secrets.NOTICIENCIAS_BOT_TOKEN == ''
         run: echo "::warning::NOTICIENCIAS_BOT_TOKEN secret is not configured — bot PRs fall back to GITHUB_TOKEN and are gated by GitHub bot-approval (checks conclude action_required and never run), so the bot cannot land PRs. Configure the fine-grained PAT to enable self-serve landing."
 
       - name: Commit and land snapshot update if changed


### PR DESCRIPTION
## Bug

PR #125 added a 'Warn when bot PAT is not configured' step whose `if:` condition referenced the `secrets` context:

```yaml
if: ${{ secrets.NOTICIENCIAS_BOT_TOKEN == '' }}
```

**GitHub rejects workflow files whose step `if:` conditions use the secrets context** — both the `${{ }}` form and the implicit form fail validation, which **disables the whole workflow** (schedule + dispatch). All three bot workflows (Sync Contract Snapshot, Generate Content Metrics, Image Delivery Quota Guard) were silently disabled from the moment #125 merged.

## Diagnosis

Empirically bisected with disposable branches (each invalid file produces a failing push-triggered validation run with zero jobs):

| Variant | Result |
| --- | --- |
| warning step with `if: ${{ secrets.X == '' }}` | FAIL |
| warning step with `if: secrets.X == ''` (implicit) | FAIL |
| warning step with no `if:` line | PASS |

Conclusion: no `if:` may reference `secrets`.

## Fix

Move the check into the step body: expose the secret through `env` (a pattern already proven in these workflows via `GH_TOKEN: ${{ secrets.NOTICIENCIAS_BOT_TOKEN || github.token }}`) and emit the `::warning::` at runtime when the value is empty:

```yaml
- name: Warn when bot PAT is not configured
  env:
    GH_TOKEN: ${{ secrets.NOTICIENCIAS_BOT_TOKEN || '' }}
  run: |
    if [ -z "$GH_TOKEN" ]; then
      echo "::warning::NOTICIENCIAS_BOT_TOKEN secret is not configured - ..."
    fi
```

Also removed the em-dash from the message (non-ASCII was a second untested variable).

## Verification

- Pushed the fix branch: zero push-triggered validation runs created (previously every workflow edit produced three failing runs).
- All bisect branches and files removed; no leftovers.
- Note: the earlier implicit-`if:` conclusion in the commit history was a false positive from run-creation timing — superseded by this branch-scoped evidence.