### PR TITLE
feat(workflows): add bot health watchdog and failure notifications

### DIFF
--- a/.github/workflows/bot-health.yml
+++ b/.github/workflows/bot-health.yml
@@ -1,0 +1,63 @@
+name: Bot Health Watchdog
+
+on:
+  schedule:
+    # Daily at 07:45 UTC, after all three scheduled bot workflows (05:17 quota,
+    # 06:17 metrics, 06:00 Mon sync) have had a chance to run.
+    - cron: '45 7 * * *'
+  workflow_dispatch:
+
+permissions:
+  actions: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check bot workflow freshness
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          failures=0
+
+          check_fresh() {
+            local workflow="$1" max_age_hours="$2" label="$3"
+            local last age_hours now
+            last="$(gh run list --workflow="$workflow" --limit 1 --json updatedAt --jq '.[0].updatedAt // empty' 2>/dev/null || true)"
+            if [ -z "$last" ]; then
+              echo "::error::Bot Health: $label ($workflow) has NO recorded runs."
+              failures=$((failures + 1))
+              return
+            fi
+            now="$(date -u +%s)"
+            age_hours="$(( ( now - $(date -u -d "$last" +%s) ) / 3600 ))"
+            echo "  $label: last run $last (${age_hours}h ago)"
+            if [ "$age_hours" -gt "$max_age_hours" ]; then
+              echo "::error::Bot Health: $label last ran ${age_hours}h ago (max ${max_age_hours}h). The workflow may be disabled or broken."
+              failures=$((failures + 1))
+            fi
+          }
+
+          # Expected cadence: daily 05:17 / 06:17; weekly Monday 06:00.
+          check_fresh "Generate Content Metrics" 30 "metrics"
+          check_fresh "Image Delivery Quota Guard" 30 "quota guard"
+          check_fresh "Sync Contract Snapshot" 192 "contract sync"
+
+          if [ "$failures" -gt 0 ]; then
+            echo "::error::Bot Health: $failures bot workflow(s) stale or missing. Check https://github.com/${{ github.repository }}/actions for disabled or failing workflows."
+            exit 1
+          fi
+          echo "All bot workflows fresh."
+
+      - name: Notify on watchdog failure
+        if: failure()
+        env:
+          BACKEND_WEBHOOK_URL: ${{ secrets.BACKEND_WEBHOOK_URL }}
+          BACKEND_WEBHOOK_TOKEN: ${{ secrets.BACKEND_WEBHOOK_TOKEN }}
+        run: |
+          cat > /tmp/bot-health-failure.json <<'EOF'
+          {"check": "bot-health-watchdog", "status": "fail", "errors": [{"message": "A scheduled bot workflow is stale or missing. The workflow may be disabled (e.g. secrets in a step if: condition) or failing repeatedly."}]}
+          EOF
+          node scripts/backend-notify.js --status=fail --event=bot_health_failed --payload-file=/tmp/bot-health-failure.json || true

--- a/.github/workflows/generate-metrics.yml
+++ b/.github/workflows/generate-metrics.yml
@@ -37,6 +37,17 @@ jobs:
         # must not run lint-staged or the full validation chain on the runner.
         run: git config core.hooksPath /dev/null
 
+      - name: Notify on bot landing failure
+        if: failure()
+        env:
+          BACKEND_WEBHOOK_URL: ${{ secrets.BACKEND_WEBHOOK_URL }}
+          BACKEND_WEBHOOK_TOKEN: ${{ secrets.BACKEND_WEBHOOK_TOKEN }}
+        run: |
+          cat > /tmp/bot-landing-failure.json <<'EOF'
+          {"check": "bot-landing", "status": "fail", "errors": [{"message": "Bot landing step failed; the PR may be left open for manual merge."}]}
+          EOF
+          node scripts/backend-notify.js --status=fail --event=bot_landing_failed --payload-file=/tmp/bot-landing-failure.json || true
+
       - name: Warn when bot PAT is not configured
         env:
           GH_TOKEN: ${{ secrets.NOTICIENCIAS_BOT_TOKEN || '' }}

--- a/.github/workflows/image-delivery-quota.yml
+++ b/.github/workflows/image-delivery-quota.yml
@@ -82,6 +82,17 @@ jobs:
           fs.appendFileSync(process.env.GITHUB_OUTPUT, `target_mode=${summary.targetMode}\n`, 'utf8');
           EOF
 
+      - name: Notify on bot failure
+        if: failure()
+        env:
+          BACKEND_WEBHOOK_URL: ${{ secrets.BACKEND_WEBHOOK_URL }}
+          BACKEND_WEBHOOK_TOKEN: ${{ secrets.BACKEND_WEBHOOK_TOKEN }}
+        run: |
+          cat > /tmp/bot-landing-failure.json <<'EOF'
+          {"check": "bot-landing", "status": "fail", "errors": [{"message": "Image delivery quota guard step failed."}]}
+          EOF
+          node scripts/backend-notify.js --status=fail --event=bot_landing_failed --payload-file=/tmp/bot-landing-failure.json || true
+
       - name: Warn when bot PAT is not configured
         env:
           GH_TOKEN: ${{ secrets.NOTICIENCIAS_BOT_TOKEN || '' }}

--- a/.github/workflows/sync-contract-snapshot.yml
+++ b/.github/workflows/sync-contract-snapshot.yml
@@ -46,6 +46,17 @@ jobs:
           BACKEND_SCHEMA_PATH="_backend_sparse/news_collector/contracts/frontend_schema.py" \
             npm run sync:contract-snapshot
 
+      - name: Notify on bot landing failure
+        if: failure()
+        env:
+          BACKEND_WEBHOOK_URL: ${{ secrets.BACKEND_WEBHOOK_URL }}
+          BACKEND_WEBHOOK_TOKEN: ${{ secrets.BACKEND_WEBHOOK_TOKEN }}
+        run: |
+          cat > /tmp/bot-landing-failure.json <<'EOF'
+          {"check": "bot-landing", "status": "fail", "errors": [{"message": "Bot landing step failed; the PR may be left open for manual merge."}]}
+          EOF
+          node scripts/backend-notify.js --status=fail --event=bot_landing_failed --payload-file=/tmp/bot-landing-failure.json || true
+
       - name: Warn when bot PAT is not configured
         env:
           GH_TOKEN: ${{ secrets.NOTICIENCIAS_BOT_TOKEN || '' }}

--- a/scripts/check-contract-sync.js
+++ b/scripts/check-contract-sync.js
@@ -1407,7 +1407,7 @@ async function main() {
       const ageDays = Math.round(age / (1000 * 60 * 60 * 24));
       if (ageDays > 7) {
         console.warn(
-          `[contract-sync] WARNING: Snapshot is ${ageDays} days old (generated ${snapshotData.generatedAt}). Consider updating with: npm run sync:contract-snapshot`
+          `[contract-sync] WARNING: Snapshot is ${ageDays} days old (generated ${snapshotData.generatedAt}). If the backend contract changed since then, update with: npm run sync:contract-snapshot (note: no-op regenerations preserve the timestamp by design).`
         );
       } else {
         console.log(


### PR DESCRIPTION
## Summary
- New **Bot Health Watchdog** (daily 07:45 UTC + manual dispatch): alerts when any scheduled bot workflow (Generate Content Metrics, Image Delivery Quota Guard, Sync Contract Snapshot) has no run within its expected window, so a silently disabled workflow is caught within a day.
- Best-effort **failure notifications** via `backend-notify.js` in the three bot workflows when landing fails (webhook secrets not configured yet — no-op today).
- Softened snapshot age warning in `scripts/check-contract-sync.js` (no-op regenerations preserve the timestamp by design).

Follows the env-based secret pattern (#126) — no `secrets` context in any `if:` expression.